### PR TITLE
fix: check home channel

### DIFF
--- a/lib/createproposal/getShareUrl.ts
+++ b/lib/createproposal/getShareUrl.ts
@@ -8,6 +8,6 @@ export const getShareUrl = (
   return `https://warpcast.com/~/compose?text=${encodeURIComponent(
     `Propose to permanently archive on Arweave for @${authorFname} in /${channelId}`
   )}&embeds[]=${FRAMES_BASE_URL}/proposal/frames?castHash=${castHash}&embeds[]=https://warpcast.com/~/conversations/${castHash}${
-    channelId ? `&channelKey=${channelId}` : ""
+    channelId && channelId !== "home" ? `&channelKey=${channelId}` : ""
   }`;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved URL generation logic for sharing proposals by refining when the `channelKey` is appended, enhancing clarity and preventing confusion in specific cases.
  
- **Bug Fixes**
	- Resolved an issue where the `channelKey` could be incorrectly included in URLs when the `channelId` was set to "home".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->